### PR TITLE
[Refactor] Simplifying import paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "tailwind-merge": "2.5.4"
       },
       "devDependencies": {
+        "@types/node": "^24.0.1",
         "@types/react": "18.2.0",
         "@types/react-dom": "18.2.0",
         "@vitejs/plugin-react": "4.3.4",
@@ -1574,6 +1575,16 @@
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
+      "integrity": "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
@@ -3244,6 +3255,13 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -9,17 +9,18 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@radix-ui/react-navigation-menu": "^1.2.1",
+    "@radix-ui/react-separator": "^1.1.0",
+    "class-variance-authority": "^0.7.0",
     "clsx": "2.1.1",
     "lucide-react": "^0.453.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.1",
-    "tailwind-merge": "2.5.4",
-    "@radix-ui/react-navigation-menu": "^1.2.1",
-    "class-variance-authority": "^0.7.0",
-    "@radix-ui/react-separator": "^1.1.0"
+    "tailwind-merge": "2.5.4"
   },
   "devDependencies": {
+    "@types/node": "^24.0.1",
     "@types/react": "18.2.0",
     "@types/react-dom": "18.2.0",
     "@vitejs/plugin-react": "4.3.4",

--- a/src/screens/MacbookAirDark/MacbookAirDark.tsx
+++ b/src/screens/MacbookAirDark/MacbookAirDark.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { AboutMeSection } from "./sections/AboutMeSection";
 import { ContactSection } from "./sections/ContactSection";
 import { NavigationSection } from "./sections/NavigationSection/NavigationSection";

--- a/src/screens/MacbookAirDark/sections/AboutMeSection/AboutMeSection.tsx
+++ b/src/screens/MacbookAirDark/sections/AboutMeSection/AboutMeSection.tsx
@@ -1,4 +1,4 @@
-import { Card } from "../../../../components/ui/card";
+import { Card } from "@components/ui/card";
 
 export const AboutMeSection = (): JSX.Element => {
   return (

--- a/src/screens/MacbookAirDark/sections/ContactSection/ContactSection.tsx
+++ b/src/screens/MacbookAirDark/sections/ContactSection/ContactSection.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
 import { GithubIcon, LinkedinIcon, Send } from "lucide-react";
-import { Input } from "../../../../components/ui/input";
-import { Textarea } from "../../../../components/ui/textarea";
-import { Button } from "../../../../components/ui/button";
-import apiService from "../../../../lib/api";
+import { Input } from "@components/ui/input";
+import { Textarea } from "@components/ui/textarea";
+import { Button } from "@components/ui/button";
+import apiService from "@lib/api";
 
 export const ContactSection = (): JSX.Element => {
   const [formData, setFormData] = useState({

--- a/src/screens/MacbookAirDark/sections/NavigationSection/NavigationSection.tsx
+++ b/src/screens/MacbookAirDark/sections/NavigationSection/NavigationSection.tsx
@@ -4,7 +4,7 @@ import {
   NavigationMenuItem,
   NavigationMenuLink,
   NavigationMenuList,
-} from "../../../../components/ui/navigation-menu";
+} from '@components/ui/navigation-menu'
 
 export const NavigationSection = (): JSX.Element => {
   // Navigation links data

--- a/src/screens/MacbookAirDark/sections/ProjectsSection/ProjectsSection.tsx
+++ b/src/screens/MacbookAirDark/sections/ProjectsSection/ProjectsSection.tsx
@@ -1,5 +1,5 @@
-import { Card, CardContent } from "../../../../components/ui/card";
-import { Separator } from "../../../../components/ui/separator";
+import { Card, CardContent } from "@components/ui/card";
+import { Separator } from "@components/ui/separator";
 
 // Project data for mapping
 const projects = [

--- a/src/screens/MacbookAirDark/sections/SkillsSection/SkillsSection.tsx
+++ b/src/screens/MacbookAirDark/sections/SkillsSection/SkillsSection.tsx
@@ -1,5 +1,5 @@
-import { Badge } from "../../../../components/ui/badge";
-import { Separator } from "../../../../components/ui/separator";
+import { Badge } from "@components/ui/badge";
+import { Separator } from "@components/ui/separator";
 
 // Define skill data for mapping
 const skillCategories = [

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,7 +20,13 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".", // 👈 necessary
+    "paths": {
+      "@components/*": ["src/components/*"],
+      "@lib/*": ["src/lib/*"],
+      "@screens/*": ["src/screens/*"]
+    },
   },
   "include": [
     "src"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,27 @@
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwind from "tailwindcss";
-import { defineConfig } from "vite";
+import path from "path";
+import { fileURLToPath } from "url";
 
-// https://vite.dev/config/
+// Fix for __dirname in ESM
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 export default defineConfig({
   plugins: [react()],
   base: "./",
   css: {
     postcss: {
       plugins: [tailwind()],
+    },
+  },
+  resolve: {
+    alias: {
+      "@components": path.resolve(__dirname, "src/components"),
+      "@lib": path.resolve(__dirname, "src/lib"),
+      "@screens": path.resolve(__dirname, "src/screens"),
+      "@hooks": path.resolve(__dirname, "src/hooks")
     },
   },
 });


### PR DESCRIPTION
- Updated `vite.config.ts` file to include the aliases
- Updated `tsconfig.app.json` file to add baseUrl and paths config

Now imports will look like:

```
import { ComponentName } from '@components/ui/component-name';
```