### PR TITLE
[Chore] Adding typescript dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "esbuild": "0.24.0",
         "globals": "15.12.0",
         "tailwindcss": "3.4.16",
+        "typescript": "^5.8.3",
         "vite": "6.0.4"
       }
     },
@@ -3255,6 +3256,20 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.8.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "esbuild": "0.24.0",
     "globals": "15.12.0",
     "tailwindcss": "3.4.16",
+    "typescript": "^5.8.3",
     "vite": "6.0.4"
   },
   "alias": {


### PR DESCRIPTION
## Add TypeScript as a Dev Dependency
This PR adds typescript as a local devDependency to the project.

### ✅ Why this is necessary
While the project already has:

- tsconfig.json and related configuration files
- .ts and .tsx source files
- type definitions like @types/react

…it was missing the actual TypeScript compiler (typescript) in package.json.
Currently, TypeScript is being resolved via npx or globally installed versions, which works locally but is not reliable or reproducible across different environments.

### ✅ Benefits of installing it locally

- Ensures consistent TypeScript version across all machines
- Prevents build errors in CI/CD or other environments without a global TypeScript install
- Improves tooling support, as IDEs and linters prefer local versions
- Makes the TypeScript usage explicit to anyone cloning or inspecting the project
- Locks version via package-lock.json for reproducible builds

### 📦 What changed
Installed TypeScript as a dev dependency:

```
npm install --save-dev typescript
```
